### PR TITLE
Top clan exclusions, discord message update

### DIFF
--- a/src/main/java/de/craftlancer/clcapture/CLCapture.java
+++ b/src/main/java/de/craftlancer/clcapture/CLCapture.java
@@ -5,7 +5,6 @@ import de.craftlancer.clclans.CLClans;
 import de.craftlancer.core.IntRingBuffer;
 import de.craftlancer.core.LambdaRunnable;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.boss.KeyedBossBar;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -111,7 +110,7 @@ public class CLCapture extends JavaPlugin implements Listener {
         FileConfiguration pointsData = YamlConfiguration.loadConfiguration(pointsFile);
         FileConfiguration typesData = YamlConfiguration.loadConfiguration(typesFile);
         
-        types = typesData.getKeys(false).stream().map(key -> new CapturePointType(typesData.getConfigurationSection(key)))
+        types = typesData.getKeys(false).stream().map(key -> new CapturePointType(this, typesData.getConfigurationSection(key)))
                 .collect(Collectors.toMap(CapturePointType::getName, a -> a));
         
         points = pointsData.getKeys(false).stream().map(key -> new CapturePoint(this, key, pointsData.getConfigurationSection(key)))

--- a/src/main/java/de/craftlancer/clcapture/CapturePoint.java
+++ b/src/main/java/de/craftlancer/clcapture/CapturePoint.java
@@ -229,7 +229,7 @@ public class CapturePoint implements Listener {
                     if (tickId % 20 == 0)
                         a.playSound(a.getLocation(), Sound.BLOCK_NOTE_BLOCK_BASS,0.5F,0.5F);
                     if (tickId % 100 == 0)
-                        a.sendMessage(MSG_PREFIX + ChatColor.YELLOW + "Your clan is too powerful to capture this point!");
+                        a.sendMessage(MSG_PREFIX + ChatColor.YELLOW + "Your clan or past clan is too powerful to capture this point!");
                     continue;
                 }
                 inRegionMap.compute(convertToOwner(a), (b, c) -> inRegionMap.containsKey(b) ? c + 1 : 1);

--- a/src/main/java/de/craftlancer/clcapture/CapturePoint.java
+++ b/src/main/java/de/craftlancer/clcapture/CapturePoint.java
@@ -12,6 +12,7 @@ import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.Particle;
+import org.bukkit.Sound;
 import org.bukkit.Tag;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -33,6 +34,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.BoundingBox;
 
 import java.time.LocalTime;
@@ -53,7 +55,8 @@ public class CapturePoint implements Listener {
     private static final String CAPTURE_MESSAGE = MSG_PREFIX + "%s §etook the capture point %s!";
     private static final String CAPTURE_MESSAGE_DISCORD = ":bannerred:%s took the capture point %s!";
     private static final String EVENT_START_MSG = MSG_PREFIX + "§eThe battle for §6%s §ehas begun!";
-    private static final String EVENT_START_MSG_DISCORD = ":bannerwhite:The battle for %s has begun! <@&661388575039946752>";
+    private static final String EVENT_TYPE_START_MSG_DISCORD = ":bannerwhite:The battle for %s capture points is beginning! <@&661388575039946752>";
+    private static final String EVENT_START_MSG_DISCORD = ":bannerwhite:The battle for %s has begun!";
     private static final String EVENT_END_MSG = MSG_PREFIX + "%s §awon the battle for §2%s§a!";
     private static final String EVENT_END_MSG_DISCORD = ":bannergreen:%s won the battle for %s!";
     private static final String CANT_OPEN_MSG = MSG_PREFIX + "§eYou can't open this chest!";
@@ -220,9 +223,18 @@ public class CapturePoint implements Listener {
         lastTime = LocalTime.now().toSecondOfDay();
         
         //If a player is within the capturepoint region, add them to the map
-        for (Player a : Bukkit.getOnlinePlayers())
-            if (isInRegion(a) && !a.isDead() && !a.isOp())
+        for (Player a : Bukkit.getOnlinePlayers()) {
+            if (isInRegion(a) && !a.isDead() && !a.isOp()) {
+                if (type.isExcludeTopClans() && type.isPlayerExcluded(a.getUniqueId())) {
+                    if (tickId % 20 == 0)
+                        a.playSound(a.getLocation(), Sound.BLOCK_NOTE_BLOCK_BASS,0.5F,0.5F);
+                    if (tickId % 100 == 0)
+                        a.sendMessage(MSG_PREFIX + ChatColor.YELLOW + "Your clan is too powerful to capture this point!");
+                    continue;
+                }
                 inRegionMap.compute(convertToOwner(a), (b, c) -> inRegionMap.containsKey(b) ? c + 1 : 1);
+            }
+        }
             
         int amountOfPlayersInRegion = inRegionMap.size();
         setOwner(inRegionMap);
@@ -424,6 +436,7 @@ public class CapturePoint implements Listener {
     }
     
     public void startEvent() {
+        type.setTopXClans(plugin.getClanPlugin().getClans().stream().sorted(Comparator.comparingDouble(Clan::calculateClanScore).reversed()).limit(type.getExcludeTopXClans()).collect(Collectors.toList()));
         previousMessageOwner = null;
         previousOwner = null;
         currentOwner = null;
@@ -440,9 +453,22 @@ public class CapturePoint implements Listener {
         
         if (type.isBroadcastStart()) {
             Bukkit.broadcastMessage(String.format(EVENT_START_MSG, this.name));
-            if (plugin.isUsingDiscord())
+            if (plugin.isUsingDiscord() && type.isPingDiscord()) {
                 DiscordUtil.queueMessage(DiscordSRV.getPlugin().getDestinationTextChannelForGameChannelName("event"),
                         String.format(EVENT_START_MSG_DISCORD, this.name));
+                
+                if (type.isPingDiscord()) {
+                    DiscordUtil.queueMessage(DiscordSRV.getPlugin().getDestinationTextChannelForGameChannelName("event"),
+                            String.format(EVENT_TYPE_START_MSG_DISCORD, type.getName()));
+                    type.setPingDiscord(false);
+                    new BukkitRunnable() {
+                        @Override
+                        public void run() {
+                            type.setPingDiscord(true);
+                        }
+                    }.runTaskLater(plugin, 300);
+                }
+            }
         }
         
         winTime = 0;

--- a/src/main/java/de/craftlancer/clcapture/CapturePointType.java
+++ b/src/main/java/de/craftlancer/clcapture/CapturePointType.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.NavigableMap;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -188,8 +189,10 @@ public class CapturePointType {
     public boolean isPlayerExcluded(UUID uuid) {
         if (!excludeTopClans)
             return false;
-        if (plugin.getClanPlugin().getClan(Bukkit.getOfflinePlayer(uuid)) == null)
-            return false;
+        Optional<PlayerPastClanStorage> optional = plugin.getPastClans().stream().filter(storage -> storage.getPlayerUUID().equals(uuid)).findFirst();
+        if (optional.isPresent())
+            if (optional.get().getLast24HourClans().stream().anyMatch(clan -> topXClans.contains(clan)))
+                return true;
         return topXClans.stream().anyMatch(clan -> clan.isMember(uuid));
     }
     

--- a/src/main/java/de/craftlancer/clcapture/PlayerPastClanStorage.java
+++ b/src/main/java/de/craftlancer/clcapture/PlayerPastClanStorage.java
@@ -1,0 +1,80 @@
+package de.craftlancer.clcapture;
+
+import de.craftlancer.clclans.Clan;
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.jetbrains.annotations.NotNull;
+
+import java.sql.SQLOutput;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class PlayerPastClanStorage implements ConfigurationSerializable {
+    
+    private CLCapture plugin;
+    private UUID playerUUID;
+    private Map<UUID, Long> clanLeaveMap;
+    
+    public PlayerPastClanStorage(CLCapture plugin, UUID playerUUID, UUID clan, long currentTime) {
+        this.plugin = plugin;
+        this.playerUUID = playerUUID;
+        
+        clanLeaveMap = new HashMap<>();
+        clanLeaveMap.put(clan,currentTime+1728000);
+    }
+    
+    public PlayerPastClanStorage(Map<String, Object> map) {
+        this.plugin = (CLCapture) Bukkit.getPluginManager().getPlugin("CLCapture");
+        clanLeaveMap = new HashMap<>();
+        
+        playerUUID = UUID.fromString((String) map.get("playerUUID"));
+        map.remove("==");
+        map.remove("playerUUID");
+        
+        map.forEach((key, value) -> {
+                UUID uuid = UUID.fromString(key);
+                long time = (long) value;
+
+                if (time < System.currentTimeMillis())
+                    return;
+                
+                clanLeaveMap.put(uuid, time);
+        });
+    }
+    
+    @Override
+    public @NotNull Map<String, Object> serialize() {
+        Map<String, Object> map = new HashMap<>();
+        
+        map.put("playerUUID", playerUUID.toString());
+        clanLeaveMap.entrySet().stream().filter(entry -> plugin.getClanPlugin().getClanByUUID(entry.getKey()) != null)
+                .forEach(entry -> map.put(entry.getKey().toString(),entry.getValue()));
+
+        return map;
+    }
+    
+    /**
+     * @return All clans that the player has been in in the last 24 hours
+     */
+    public List<Clan> getLast24HourClans() {
+        return clanLeaveMap.entrySet().stream()
+                .filter(entry -> System.currentTimeMillis() < entry.getValue() && plugin.getClanPlugin().getClanByUUID(entry.getKey()) != null)
+                .map(entry -> plugin.getClanPlugin().getClanByUUID(entry.getKey())).collect(Collectors.toList());
+    }
+    
+    public void add(UUID clanUUID, long currentTime) {
+        clanLeaveMap.put(clanUUID, currentTime+1728000);
+    }
+    
+    public void remove(UUID clanUUID) {
+        clanLeaveMap.remove(clanUUID);
+    }
+    
+    public UUID getPlayerUUID() {
+        return playerUUID;
+    }
+}

--- a/src/main/java/de/craftlancer/clcapture/commands/CaptureTypeCommandHandler.java
+++ b/src/main/java/de/craftlancer/clcapture/commands/CaptureTypeCommandHandler.java
@@ -27,6 +27,8 @@ public class CaptureTypeCommandHandler extends SubCommandHandler {
         registerSubCommand("pmodremove", new TypePModRemoveCommand(plugin));
         registerSubCommand("setartifactmodifier", new TypeSetArtifactModifierCommand(plugin));
         registerSubCommand("setDays", new TypeSetDaysCommand(plugin));
+        registerSubCommand("setExcludeTopClans", new TypeSetExcludeTopClansCommand(plugin));
+        registerSubCommand("setExcludeTopXClans", new TypeSetExcludeTopXClansCommand(plugin));
     }
 
     @Override

--- a/src/main/java/de/craftlancer/clcapture/commands/TypeSetExcludeTopClansCommand.java
+++ b/src/main/java/de/craftlancer/clcapture/commands/TypeSetExcludeTopClansCommand.java
@@ -1,0 +1,54 @@
+package de.craftlancer.clcapture.commands;
+
+import de.craftlancer.clcapture.CLCapture;
+import de.craftlancer.clcapture.CapturePointType;
+import de.craftlancer.core.Utils;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class TypeSetExcludeTopClansCommand extends CaptureSubCommand {
+    public TypeSetExcludeTopClansCommand(CLCapture plugin) {
+        super(CLCapture.ADMIN_PERMISSION, plugin, false);
+    }
+    
+    @Override
+    protected String execute(CommandSender sender, Command command, String s, String[] args) {
+        if (!checkSender(sender))
+            return CLCapture.PREFIX + "You must be a player to use this.";
+        if (args.length < 3)
+            return CLCapture.PREFIX + "You must specify a type id!";
+    
+        if (args.length < 4)
+            return CLCapture.PREFIX + "You must specify true/false!";
+    
+        Optional<CapturePointType> type = getPlugin().getTypes().values().stream().filter(a -> a.getName().equals(args[2])).findFirst();
+    
+        if (!type.isPresent())
+            return CLCapture.PREFIX + "This point does not exist.";
+        
+        boolean bool = Boolean.parseBoolean(args[3]);
+        type.get().setExcludeTopClans(bool);
+        return CLCapture.PREFIX + "§aThis point will now " + (bool ? "§cexclude" : "§2not exclude") + " §atop clans.";
+    }
+    
+    @Override
+    protected List<String> onTabComplete(CommandSender sender, String[] args) {
+        if (args.length == 3)
+            return Utils.getMatches(args[2], getPlugin().getTypes().values().stream().map(CapturePointType::getName).collect(Collectors.toList()));
+        if (args.length == 4)
+            return Utils.getMatches(args[3], Arrays.asList("true", "false"));
+    
+        return Collections.emptyList();
+    }
+    
+    @Override
+    public void help(CommandSender commandSender) {
+    
+    }
+}

--- a/src/main/java/de/craftlancer/clcapture/commands/TypeSetExcludeTopXClansCommand.java
+++ b/src/main/java/de/craftlancer/clcapture/commands/TypeSetExcludeTopXClansCommand.java
@@ -1,0 +1,60 @@
+package de.craftlancer.clcapture.commands;
+
+import de.craftlancer.clcapture.CLCapture;
+import de.craftlancer.clcapture.CapturePointType;
+import de.craftlancer.core.Utils;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class TypeSetExcludeTopXClansCommand extends CaptureSubCommand {
+    public TypeSetExcludeTopXClansCommand(CLCapture plugin) {
+        super(CLCapture.ADMIN_PERMISSION, plugin, false);
+    }
+    
+    @Override
+    protected String execute(CommandSender sender, Command command, String s, String[] args) {
+        if (!checkSender(sender))
+            return CLCapture.PREFIX + "You must be a player to use this.";
+        if (args.length < 3)
+            return CLCapture.PREFIX + "You must specify a type id!";
+    
+        if (args.length < 4)
+            return CLCapture.PREFIX + "You must specify a number!";
+    
+        Optional<CapturePointType> type = getPlugin().getTypes().values().stream().filter(a -> a.getName().equals(args[2])).findFirst();
+    
+        if (!type.isPresent())
+            return CLCapture.PREFIX + "This point does not exist.";
+    
+        int excludeXClans;
+        try {
+            excludeXClans = Integer.parseInt(args[3]);
+        } catch (NumberFormatException e) {
+            return CLCapture.PREFIX + "You must specify an integer!";
+        }
+        
+        type.get().setExcludeTopXClans(excludeXClans);
+        return CLCapture.PREFIX + "§aThis point will now exclude the top §b" + excludeXClans + " §aclans.";
+    }
+    
+    @Override
+    protected List<String> onTabComplete(CommandSender sender, String[] args) {
+        if (args.length == 3)
+            return Utils.getMatches(args[2], getPlugin().getTypes().values().stream().map(CapturePointType::getName).collect(Collectors.toList()));
+        if (args.length == 4)
+            return Utils.getMatches(args[3], Collections.singletonList("#"));
+    
+        return Collections.emptyList();
+    }
+    
+    @Override
+    public void help(CommandSender commandSender) {
+    
+    }
+}

--- a/src/main/resources/pastClans.yml
+++ b/src/main/resources/pastClans.yml
@@ -1,0 +1,1 @@
+pastClans: []


### PR DESCRIPTION
- Discord messages with PINGS will be sent once per TYPE upon a point starting.
- Capture points can now ignore players who are in a top clan, the top amount of clans checked can be set along with a boolean to do this check in the first place
- The top clans are calculated at the start of an event (better accuracy then once per restart, or once for every tick)